### PR TITLE
minor accessibility issue fix for 404 page

### DIFF
--- a/layouts/_default/404.html
+++ b/layouts/_default/404.html
@@ -6,7 +6,7 @@
   }
 </style>
 
-<main role="main" class="my-5">
+<main id="main" class="my-5">
   <header class="container mt-5">
     <div class="row">
       <div class="col-11 mx-auto text-center mt-2">
@@ -29,8 +29,7 @@
 
   <div class="container text-center mb-5 pb-5">
     <p>The page you are looking for has moved or has not been constructed yet.</p>
-    <p>Return to the <a href="/">Modus
-        home page</a>, and let's try again.</p>
+    <p>Return to the <a href="/">home page</a>, and let's try again.</p>
   </div>
 </main>
 

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-<main role="main" id="main">
+<main id="main">
 
   <header>
     <div class="container-fluid pt-5">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
   </div>
 </header>
 
-<main role="main" class="my-5 container">
+<main class="my-5 container">
   {{ if .Params.componentsHome }}
 
   <div class="container mb-5">


### PR DESCRIPTION
Fix for a minor accessibility issue discovered by netlify-plugin-a11y.
The skip to content link goes to '#main', but the 404 page was missing this id. this PR fixes the issue.
Also removed unneeded role="main" as all modern browsers already assume that role for main element.