### PR TITLE
Fix some color contrast CSS issues in the docs

### DIFF
--- a/assets/css/_codefences.scss
+++ b/assets/css/_codefences.scss
@@ -247,5 +247,5 @@
   color: #40a070;
 } /* Literal.Number.Integer.Long */
 .highlight .p {
-  opacity: 0.6;
+  opacity: 0.7;
 }

--- a/assets/css/_menu-right.scss
+++ b/assets/css/_menu-right.scss
@@ -15,7 +15,7 @@
 
 html[data-theme="light"] {
   #TableOfContents li a {
-    color: #6a6976;
+    color: #585c65;
   }
 
   #TableOfContents li a:hover {
@@ -35,7 +35,6 @@ html[data-theme="dark"] {
 
 // sub-menu indenting
 .menu-right #TableOfContents li li a {
-  color: #888 !important;
   text-indent: 5px;
 }
 
@@ -46,7 +45,7 @@ html[data-theme="dark"] {
 
 // scrollspy color
 .menu-right #TableOfContents li .active {
-  color: #000 !important;
+  color: #000;
   border-left: 1px solid #0d6aa8 !important;
 }
 

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -37,7 +37,7 @@ main h2 em {
 
 - [Dark mode theme](/foundations/dark-mode-theme/) added
 - [Remove Internet Explorer 11](/device-support/) from browserslist config
-- Change focus-outline color from black to blue
+- Change focus-outline color from black {{< color-preview hex="#000">}} to blue {{< color-preview hex="#0063A3">}}
 - Remove background-color: from modus-header. This rule prevented the navbar-dark and navbar-blue from working as intended.
 
 ## v1.4.1 _2022-04-22_

--- a/content/components/pagination.md
+++ b/content/components/pagination.md
@@ -102,7 +102,7 @@ Use `.disabled` to make links appear un-clickable and
 
 Add `.pagination-lg` to your `.pagination` for a larger size.
 
-{{< example id="example-pagination-sizing" >}}
+{{< example id="example-pagination-large" >}}
 <nav aria-label="Page navigation example">
   <ul class="pagination pagination-lg">
     <li class="page-item disabled">
@@ -142,14 +142,14 @@ Add `.pagination-lg` to your `.pagination` for a larger size.
 
 Add `.pagination-sm` to your `.pagination` for a smaller size.
 
-{{< example id="example-pagination-sizing" >}}
+{{< example id="example-pagination-small" >}}
 <nav aria-label="Page navigation example">
   <ul class="pagination pagination-sm">
     <li class="page-item disabled">
       <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
     </li>
     <li class="page-item">
-      <a class="page-link" href="#">
+      <a class="page-link" href="#" aria-label="Previous">
         <i class="modus-icons">chevron_left</i>
       </a>
     </li>

--- a/content/foundations/grid-and-spacing.md
+++ b/content/foundations/grid-and-spacing.md
@@ -25,6 +25,7 @@ components.
       <th>Example</th>
     </tr>
   </thead>
+  <tbody>
   <tr>
     <td>Level 1</td>
     <td>0.25</td>
@@ -65,6 +66,7 @@ components.
       <div class="d-inline-block pt-5 pr-5 bg-danger"></div>
     </td>
   </tr>
+ </tbody>
 </table>
 
 ### Notation

--- a/content/foundations/typography.md
+++ b/content/foundations/typography.md
@@ -37,7 +37,7 @@ many type styles make a layout unbalanced and difficult to manage.
 
 #### Type Scale
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
     <thead class="thead-light">
       <tr>
         <th>Category</th>

--- a/layouts/partials/menu-right.html
+++ b/layouts/partials/menu-right.html
@@ -20,7 +20,7 @@
 More Information
 </h5>
 <ul class="list-unstyled pl-0 ml-0">
-<li><a href="https://modus.trimble.com/{{- .Params.styleguideURL -}}" class="nav-link text-dark text-decoration-none filter-desaturate" target="_blank" rel="noopener">Modus Style Guide</a></li>
+<li><a href="https://modus.trimble.com/{{- .Params.styleguideURL -}}" class="nav-link filter-desaturate" target="_blank" rel="noopener">Modus Style Guide</a></li>
 </ul>
 {{- end -}}
 </div>


### PR DESCRIPTION
Issues discovered and fixed:
- changes the code highlight for `<` and `>` opacity to improve contrast slightly
- changes the right-side menu links to be a slightly darker gray so they meet contrast accessibility test
- use color hex value codes on Changelog
- use unique IDs on the small and large pagination variants
- remove `.bg-white` class from typography page as it makes it black in dark-mode which is incorrect.