### PR TITLE
Fixes a11y issues on Progress Bars and Inputs pages

### DIFF
--- a/content/components/inputs.md
+++ b/content/components/inputs.md
@@ -3,7 +3,7 @@ title: "Inputs"
 layout: "single"
 description: "Input boxes gather information from users. Labels sit atop these elements."
 components: true
-keywords: forms, form
+keywords: forms, form, select
 aliases:
   - "/components/forms/"
 styleguideURL: "components/inputs/"
@@ -71,8 +71,8 @@ classes, form layout, and more.
     </div>
   </div>
   <div class="form-group">
-    <label for="exampleFormControlSelect1">Custom Select Outlined</label>
-    <select class="custom-select form-control" id="exampleFormControlSelect2">
+    <label for="exampleFormSelect1">Custom Select</label>
+    <select class="custom-select form-control" id="exampleFormSelect1">
       <option>Option 1</option>
       <option>Option 2</option>
       <option>Option 3</option>
@@ -210,8 +210,8 @@ For large input variants, add `.form-control-lg` to the input and
   </div>
 </div>
 <div class="form-group">
-  <label class="label-lg" for="exampleFormControlSelect1">Custom Select Outlined</label>
-  <select class="custom-select form-control form-control-lg" id="exampleFormControlSelect2">
+  <label class="label-lg" for="exampleFormSelect2">Custom Select</label>
+  <select class="custom-select form-control form-control-lg" id="exampleFormSelect2">
     <option>Option 1</option>
     <option>Option 2</option>
     <option>Option 3</option>

--- a/content/components/progress-bars.md
+++ b/content/components/progress-bars.md
@@ -26,7 +26,7 @@ Put that all together, and you have the following example.
 
 {{< example id="example-progress" class="d-flex bg-light flex-column" >}}
 <div class="progress" aria-busy="true">
-  <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Please wait until the operation is finished.">
+  <div class="progress-bar" role="progressbar" aria-label="Progress" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Please wait until the operation is finished.">
   </div>
 </div>
 <div class="text-left text-dark">
@@ -38,7 +38,7 @@ Put that all together, and you have the following example.
 
 {{< example id="example-progress-sm" class="d-flex bg-light flex-column" >}}
 <div class="progress progress-sm" aria-busy="true">
-  <div class="progress-bar" role="progressbar" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Please wait until the operation is finished.">
+  <div class="progress-bar" role="progressbar" aria-label="Progress" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Please wait until the operation is finished.">
   </div>
 </div>
 {{</ example >}}

--- a/content/sample-page/sample-page-152.md
+++ b/content/sample-page/sample-page-152.md
@@ -13,9 +13,9 @@ hideFooter: true
 sitemap_exclude: true
 version: "1.5.2"
 date: "2022-07-08"
-modusCSS: "https://modus.trimble.com/css/"
-modusLayoutCSS: "https://cdn.jsdelivr.net/npm/@trimbleinc/modus-bootstrap@1/dist/modus-layout.min.css"
-modusLayoutJS: "https://cdn.jsdelivr.net/npm/@trimbleinc/modus-bootstrap@1/dist/modus-layout.min.js"
+modusCSS: "https://cdn.jsdelivr.net/npm/@trimbleinc/modus-bootstrap@1.5.2/dist/"
+modusLayoutCSS: "https://cdn.jsdelivr.net/npm/@trimbleinc/modus-bootstrap@1.5.2/dist/modus-layout.min.css"
+modusLayoutJS: "https://cdn.jsdelivr.net/npm/@trimbleinc/modus-bootstrap@1.5.2/dist/modus-layout.min.js"
 images:
   - "/icon.png"
 ---

--- a/layouts/_default/components.html
+++ b/layouts/_default/components.html
@@ -26,7 +26,7 @@
           <input class="form-control form-control-lg w-100 search" id="search" placeholder="Start typing to filter..."
             type="search" autocomplete="off" title="" onkeypress="return event.keyCode!=13">
             <div class="input-icon">
-              <i class="modus-icon material-icons">search</i>
+              <i class="modus-icon material-icons notranslate">search</i>
             </div>
             </div>
         </form>

--- a/layouts/_default/sample-page.html
+++ b/layouts/_default/sample-page.html
@@ -2743,45 +2743,55 @@
               <h3 id="progress-spinners">Progress and Spinners</h3>
               <div class="d-flex flex-column spaced-bottom">
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" aria-valuenow="0" aria-valuemin="0"
+                    aria-valuemax="100">
                   </div>
                 </div>
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 25%" aria-valuenow="25"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 50%" aria-valuenow="50"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 75%" aria-valuenow="75"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress">
-                  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 100%" aria-valuenow="100"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
               </div>
               <div class="d-flex flex-column spaced-bottom">
                 <div class="progress progress-sm">
-                  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" aria-valuenow="0" aria-valuemin="0"
+                    aria-valuemax="100">
                   </div>
                 </div>
                 <div class="progress progress-sm">
-                  <div class="progress-bar" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 25%" aria-valuenow="25"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress progress-sm">
-                  <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 50%" aria-valuenow="50"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress progress-sm">
-                  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 75%" aria-valuenow="75"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
                 <div class="progress progress-sm">
-                  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0"
+                  <div class="progress-bar" role="progressbar" aria-label="Example Progress Bar" style="width: 100%" aria-valuenow="100"
+                    aria-valuemin="0"
                     aria-valuemax="100"></div>
                 </div>
               </div>


### PR DESCRIPTION
## Description

- Fix duplicate ID on form inputs page
- Fix missing aria-label on progress bars page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

locally with Edge v103 on Windows 10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Existing tests pass locally with my changes
