### PR TITLE
Minor docs fixes

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -97,7 +97,7 @@ main h2 em {
 ## v1.1.0 _2021-08-12_
 
 - Change box-shadow color from blue to trimble gray <small>([ETHER-134](https://bitbucket.trimble.tools/projects/TMDS/repos/modus-bootstrap/pull-requests/204/overview))</small>
-- Fix for SASS deprecation warnings for adjust-color() saturation <small>([#202](https://bitbucket.trimble.tools/projects/TMDS/repos/modus-bootstrap/pull-requests/202/overview))</small>
+- Fix for Sass deprecation warnings for adjust-color() saturation <small>([#202](https://bitbucket.trimble.tools/projects/TMDS/repos/modus-bootstrap/pull-requests/202/overview))</small>
 - Change `<small>` and `.small` font-size from 10.5px to 12px <small>([DDS-174](https://jira.trimble.tools/browse/DDS-174))</small>
 - Custom Switch CSS fix for IE11 <small>([ETHER-126](https://bitbucket.trimble.tools/projects/TMDS/repos/modus-bootstrap/pull-requests/201/overview))</small>
 - Drop Edge Legacy support <small>([ETHER-132](https://jira.trimble.tools/browse/ETHER-132))</small>
@@ -107,7 +107,7 @@ main h2 em {
 
 - Update to [Bootstrap v4.6.0](https://github.com/twbs/bootstrap/releases/tag/v4.6.0)
 - Input Field Placeholder Shift fix <small>([DDS-133](https://jira.trimble.tools/browse/DDS-133))</small>
-- Address SASS deprecation warnings for adjust-color() <small>([ETHER-129](https://jira.trimble.tools/browse/ETHER-129))</small>
+- Address Sass deprecation warnings for adjust-color() <small>([ETHER-129](https://jira.trimble.tools/browse/ETHER-129))</small>
 - Fix for Indeterminate Checkbox SVG size /position <small>([DDS-107](https://jira.trimble.tools/browse/DDS-107))</small>
 
 ## v1.0.0 _2020-12-08_

--- a/content/components/chips.md
+++ b/content/components/chips.md
@@ -19,7 +19,6 @@ To specify the style, use one of these classes:
 
 - `.chip-solid`
 - `.chip-outline`
-- `.chip-reverse`
 
 ### Input Chips
 

--- a/content/components/sliders.md
+++ b/content/components/sliders.md
@@ -14,7 +14,7 @@ StyleGuide: "components/sliders/"
 
 Create custom `<input type="range">` controls with `.custom-range`.
 
-Only IE and Firefox currently support "filling" in their track from the left
+Only Firefox currently support "filling" in their track from the left
 of the thumb so only those browsers show that styling.
 
 ### Basic range

--- a/content/getting-started/index.md
+++ b/content/getting-started/index.md
@@ -14,7 +14,7 @@ The Modus Front-end Framework is an HTML/CSS library developed as a common, open
 
 ## Background
 
-Modus Bootstrap is built upon and extends the Bootstrap 4 code framework. It is a responsive framework for web and mobile uses. You can use the CSS files as is, or integrate the SASS files into your own application if you wish to modify it further.
+Modus Bootstrap is built upon and extends the Bootstrap 4 code framework. It is a responsive framework for web and mobile uses. You can use the CSS files as is, or integrate the Sass files into your own application if you wish to modify it further.
 
 ## CDN
 
@@ -62,9 +62,9 @@ When using core Bootstrap components like Modals and Accordions, include [ngx-bo
 
 More information about component support of ngx-bootstrap can be found on the [Status page](/status/).
 
-## Customize using SASS
+## Customize using Sass
 
-The SASS files will be found in the `/scss` directory.
+The Sass files will be found in the `/scss` directory.
 
 ### File structure
 
@@ -93,7 +93,7 @@ You can also start to add parts of Bootstrap under the `// Optional` section as 
 
 The main file to focus on is the `_theme.scss` file (and/or `_theme-dark.scss` if you want a dark look).
 
-You should copy this file from `/node_modules/@trimbleinc/modus-bootstrap/scss/components` to your own SASS directory and import your copy instead of the Modus bootstrap version in your main SASS file.
+You should copy this file from `/node_modules/@trimbleinc/modus-bootstrap/scss/components` to your own Sass directory and import your copy instead of the Modus bootstrap version in your main Sass file.
 
 This example shows you how you should structure your main file. The order in which files are imported matters.
 

--- a/content/utilities/flex.md
+++ b/content/utilities/flex.md
@@ -276,8 +276,6 @@ Responsive variations also exist for `flex-grow` and `flex-shrink`.
 
 Flexbox can do some pretty awesome things when you mix flex alignments with auto margins. Shown below are three examples of controlling flex items via auto margins: default (no auto margin), pushing two items to the right (`.mr-auto`), and pushing two items to the left (`.ml-auto`).
 
-**Unfortunately, IE11 does not properly support auto margins on flex items whose parent has a non-default** `justify-content `value. [See this StackOverflow answer](https://stackoverflow.com/a/37535548) for more details.
-
 {{< example id="example-flex-auto-margins" >}}
 <div class="d-flex highlighted mb-3">
   <div class="p-2 highlighted">Flex item</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -44,8 +44,8 @@
       </div>
       <div class="col-12 col-sm-6 text-sm-right small">
         <a href="https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/data-privacy-center"
-          target="_blank">Privacy Center</a> -
-        <a href="https://www.trimble.com/en/legal/terms-and-conditions/terms-of-use" target="_blank">Terms of Use</a> -
+          target="_blank" rel="noopener">Privacy Center</a> -
+        <a href="https://www.trimble.com/en/legal/terms-and-conditions/terms-of-use" target="_blank" rel="noopener">Terms of Use</a> -
          Modus Version: {{ .Site.Params.modusBootstrapVersion }}</a>
       </div>
     </div>


### PR DESCRIPTION
## Description

- Add `rel="noopener"` to external links in footer to address potential issue reported by LGTM
- Remove mentions about IE 11 compatibility now that IE is no longer supported
- Correct capitalization for Sass
- Remove mention of `chip-reverse` class (not used/needed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Existing tests pass locally with my changes
