### PR TITLE
remove lighthouse from Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,16 +29,6 @@ package = "netlify-plugin-a11y"
 
   resultMode = "warn" # is "error" by default
 
-[[plugins]]
-package = "@netlify/plugin-lighthouse"
-
-  # optional, fails build when a category is below a threshold
-  [plugins.inputs.thresholds]
-    performance = 0.6
-    accessibility = 0.8
-    best-practices = 0.8
-    seo = 0.7
-
 [[headers]]
   for = "favicon.*"
   [headers.values]


### PR DESCRIPTION
it is no longer recommended to use this via config and instead install newer version from web UI.

![image](https://user-images.githubusercontent.com/1212885/181728154-a2064e81-e14f-47a6-bc49-5d055547d625.png)
