### PR TITLE
Add Modus-branded custom 404 page

### DIFF
--- a/build/staticwebapp.config.json
+++ b/build/staticwebapp.config.json
@@ -1,4 +1,18 @@
 {
+  "globalHeaders": {
+    "Content-Security-Policy": "upgrade-insecure-requests",
+    "Permissions-Policy": "autoplay=()",
+    "Referrer-Policy": "no-referrer-when-downgrade",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-XSS-Protection": "0"
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/404/",
+      "statusCode": 404
+    }
+  },
   "routes": [
     {
       "route": "/favicon.*",
@@ -12,13 +26,5 @@
         "cache-control": "public, max-age=15770000"
       }
     }
-  ],
-  "globalHeaders": {
-    "Content-Security-Policy": "upgrade-insecure-requests",
-    "Permissions-Policy": "autoplay=()",
-    "Referrer-Policy": "no-referrer-when-downgrade",
-    "X-Content-Type-Options": "nosniff",
-    "X-Frame-Options": "SAMEORIGIN",
-    "X-XSS-Protection": "0"
-  }
+  ]
 }

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -33,13 +33,13 @@ main h2 em {
 }
 </style>
 
-## v1.5.4 - _2022-08-26_
+## v1.5.4 _2022-08-26_
 
-- Fix for radio button tap target area
+- Fix for [radio button](/components/radio-buttons/) tap target area
 - Removed unused small checkboxes, small radios and small switches
-- Updated message background and text colors
+- Updated [message](/components/messages/) background and text colors
 
-## v1.5.3 - _2022-08-05_
+## v1.5.3 _2022-08-05_
 
 - Update to [Bootstrap v4.6.2](https://github.com/twbs/bootstrap/releases/tag/v4.6.2)
 - Updated style for [Chips active state](/components/chips/).

--- a/content/cookies.md
+++ b/content/cookies.md
@@ -14,11 +14,3 @@ sitemap_exclude: true
 "Cookies" are pieces of information that a web site transfers to an
 individual's hard drive for record-keeping purposes. We don't use any on this site.
 </p>
-<div id="optanon-cookie-policy" hidden></div>
-<br><br>
-<!-- OneTrust Cookies Settings button start -->
-<a class="btn btn-primary optanon-show-settings" id="optanon-show-settings" hidden>
-Cookie Settings
-</a>
-</div>
-</div>


### PR DESCRIPTION
Adds a custom 404 page:
https://www.loekvandenouweland.com/content/custom-404-page-on-azure-static-web-app.html

So it'll show:
https://modus-bootstrap.trimble.com/404
instead of Microsoft branded one:
https://modus-bootstrap.trimble.com/broken-link


