### PR TITLE
Add Progress Bar XS example

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -35,11 +35,11 @@ main h2 em {
 
 ## v1.6.0 _2023-05-15_
 
-- Change Tooltips background color to Gray 4 (`#90939f`)
-- Add smaller progress-bar variant (4px)
+- Change [Tooltips](/components/tooltips/) background color to Gray 4 (`#90939f`)
+- Add smaller [progress-bar](/components/progress-bars/) variant (4px)
 - Increase form-text size to 11px (from 10px) and add new `.form-text-lg` class (font size: 12px)
 - Add focus state for checkboxes, radios and switches
-- Blue navbar color change from `col_trimble_blue_dark` to `col_blue_dark`
+- Blue [navbar](/components/navbar/#blue-variant) color change from `col_trimble_blue_dark` to `col_blue_dark`
 - Blue navbar button hover and active state color changes for improved accessibility
 
 ## v1.5.6 _2023-03-20_

--- a/content/components/progress-bars.md
+++ b/content/components/progress-bars.md
@@ -43,6 +43,15 @@ Put that all together, and you have the following example.
 </div>
 {{</ example >}}
 
+### Compact Variant
+
+{{< example id="example-progress-xs" class="d-flex bg-light flex-column" >}}
+<div class="progress progress-xs" aria-busy="true">
+  <div class="progress-bar" role="progressbar" aria-label="Progress" style="width: 25%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Please wait until the operation is finished.">
+  </div>
+</div>
+{{</ example >}}
+
 <!-- {{< example id="example-progress" class="d-flex bg-light flex-column" >}}
 <div class="progress">
   <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>

--- a/content/components/radio-buttons.md
+++ b/content/components/radio-buttons.md
@@ -18,9 +18,7 @@ Give the `<input>` a class of `.custom-control-input` and the `<label>` a class 
 ### Radios
 
 <!-- prettier-ignore-start -->
-
 {{< example id="example-radio" class="d-flex" >}}
-
 <div class="form-group">
   <div class="custom-control custom-radio">
     <input type="radio" checked="" class="custom-control-input" id="exampleRadio" name="exampleRadio" value="customEx">


### PR DESCRIPTION
This PR adds the new 'xs' size to the Progress Bars page:
https://modus-bootstrap.trimble.com/components/progress-bars/

Plus minor update to Changelog to link to the updated component pages
